### PR TITLE
Switched from using socks-client to socks

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "socks-proxy-agent",
-  "version": "1.0.1",
+  "version": "1.0.0",
   "description": "A SOCKS (v4a) proxy `http.Agent` implementation for HTTP and HTTPS",
   "main": "socks-proxy-agent.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "agent-base": "~1.0.1",
     "extend": "~1.2.1",
-    "socks": "~1.0.0"
+    "socks": "~1.1.5"
   },
   "devDependencies": {
     "mocha": "2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "socks-proxy-agent",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A SOCKS (v4a) proxy `http.Agent` implementation for HTTP and HTTPS",
   "main": "socks-proxy-agent.js",
   "scripts": {
@@ -27,7 +27,7 @@
   "dependencies": {
     "agent-base": "~1.0.1",
     "extend": "~1.2.1",
-    "socks-client": "~1.1.2"
+    "socks": "~1.0.0"
   },
   "devDependencies": {
     "mocha": "2"

--- a/socks-proxy-agent.js
+++ b/socks-proxy-agent.js
@@ -8,7 +8,7 @@ var url = require('url');
 var dns = require('dns');
 var extend = require('extend');
 var Agent = require('agent-base');
-var SocksClient = require('socks-client');
+var SocksClient = require('socks');
 var inherits = require('util').inherits;
 
 /**


### PR DESCRIPTION
I recently acquired the "socks" npm package and have renamed my "socks-client" that you are using to "socks". I've added a deprecation message to all socks-client versions but I will be leaving the package itself it up for foreseeable future. However all new features and bug fixes will be published under the socks name. 