### PR TITLE
Always resume socks connection

### DIFF
--- a/socks-proxy-agent.js
+++ b/socks-proxy-agent.js
@@ -101,8 +101,8 @@ function connect (req, opts, fn) {
       opts.hostname = null;
       opts.port = null;
       s = tls.connect(opts);
-      socket.resume();
     }
+    socket.resume();
     fn(null, s);
   }
 


### PR DESCRIPTION
Sock-client paused the socket before passing it to us, which makes node's HTTP parser never receives data from 'data' event.