### PR TITLE
Updated to socks v2 ( 2.1.6 )

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,7 @@
 /node_modules
+
+# mac files
+*.DS_Store
+
+# vim temp files
+*.sw?

--- a/index.js
+++ b/index.js
@@ -107,8 +107,6 @@ SocksProxyAgent.prototype.callback = function connect(req, opts, fn) {
       s = tls.connect(opts);
     }
 
-    // socket.resume();
-
     fn(null, s);
   }
 
@@ -130,8 +128,6 @@ SocksProxyAgent.prototype.callback = function connect(req, opts, fn) {
     },
     command: 'connect'
   };
-
-  // console.log( options )
 
   if (proxy.authentication) {
     options.proxy.authentication = proxy.authentication;

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ var tls; // lazy-loaded...
 var url = require('url');
 var dns = require('dns');
 var Agent = require('agent-base');
-var SocksClient = require('socks');
+var SocksClient = require('socks').SocksClient;
 var inherits = require('util').inherits;
 
 /**
@@ -90,7 +90,9 @@ SocksProxyAgent.prototype.callback = function connect(req, opts, fn) {
   var proxy = this.proxy;
 
   // called once the SOCKS proxy has connected to the specified remote endpoint
-  function onhostconnect(err, socket) {
+  function onhostconnect(err, result) {
+    var socket = result.socket
+
     if (err) return fn(err);
     var s = socket;
     if (opts.secureEndpoint) {
@@ -104,14 +106,16 @@ SocksProxyAgent.prototype.callback = function connect(req, opts, fn) {
       opts.port = null;
       s = tls.connect(opts);
     }
-    socket.resume();
+
+    // socket.resume();
+
     fn(null, s);
   }
 
   // called for the `dns.lookup()` callback
   function onlookup(err, ip) {
     if (err) return fn(err);
-    options.target.host = ip;
+    options.destination.host = ip;
     SocksClient.createConnection(options, onhostconnect);
   }
 
@@ -121,11 +125,14 @@ SocksProxyAgent.prototype.callback = function connect(req, opts, fn) {
       port: +proxy.port,
       type: proxy.version
     },
-    target: {
+    destination: {
       port: +opts.port
     },
     command: 'connect'
   };
+
+  // console.log( options )
+
   if (proxy.authentication) {
     options.proxy.authentication = proxy.authentication;
     options.proxy.userid = proxy.userid;

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "agent-base": "^4.1.0",
-    "socks": "^1.1.10"
+    "socks": "^2.1.6"
   },
   "devDependencies": {
     "mocha": "^3.4.2",

--- a/package.json
+++ b/package.json
@@ -25,12 +25,12 @@
     "url": "https://github.com/TooTallNate/node-socks-proxy-agent/issues"
   },
   "dependencies": {
-    "agent-base": "^4.1.0",
-    "socks": "^2.1.6"
+    "agent-base": "~4.1.0",
+    "socks": "~2.1.6"
   },
   "devDependencies": {
-    "mocha": "^3.4.2",
-    "raw-body": "^2.2.0",
+    "mocha": "~3.4.2",
+    "raw-body": "~2.2.0",
     "socksv5": "0.0.6"
   }
 }


### PR DESCRIPTION
Migration updates for socks v2 following: https://github.com/JoshGlazebrook/socks/blob/master/docs/migratingFromV1.md

With inspiration from @knoxcard

I maintain https://github.com/talmobi/tor-request and have switched to using `node-socks-proxy-agent` for version 2.0.0 since socks v2 does not include the agent  handling -- however I forked your project and published to `@talmobi/node-socks-proxy-agent` with updates to using socks v2 -- these are the updates I applied and are using.