### PR TITLE
Uncaught TypeError: Cannot read property 'socket' of undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -91,9 +91,16 @@ SocksProxyAgent.prototype.callback = function connect(req, opts, fn) {
 
   // called once the SOCKS proxy has connected to the specified remote endpoint
   function onhostconnect(err, result) {
-    var socket = result.socket
-
     if (err) return fn(err);
+
+    var socket;
+
+    try {
+      socket = result.socket;
+    } catch ( err ) {
+      return fn(err);
+    }
+
     var s = socket;
     if (opts.secureEndpoint) {
       // since the proxy is connecting to an SSL server, we have

--- a/index.js
+++ b/index.js
@@ -93,13 +93,7 @@ SocksProxyAgent.prototype.callback = function connect(req, opts, fn) {
   function onhostconnect(err, result) {
     if (err) return fn(err);
 
-    var socket;
-
-    try {
-      socket = result.socket;
-    } catch ( err ) {
-      return fn(err);
-    }
+    var socket = result.socket;
 
     var s = socket;
     if (opts.secureEndpoint) {


### PR DESCRIPTION
Halåj, this is a patch for a bug when a connection fails we are trying to access a property on the undefined `result` object instead of first handling the actual connection error.

Opened an issue for this also in case others have same problem: https://github.com/TooTallNate/node-socks-proxy-agent/issues/19

fix for `Uncaught TypeError: Cannot read property 'socket' of undefined`

bugfix: `Cannot read property 'socket' of undefined`

error: `Uncaught TypeError: Cannot read property 'socket' of undefined`

description:
handle connection error first before attempting to get result.socket
result will be undefined if there is a connection error, and instead
of handling the connection error, we will crash on trying to reference
socket from an 'undefined' result object