### PR TITLE
Fix README, 'secure' argument no longer used

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,7 @@ console.log('attempting to GET %j', endpoint);
 var opts = url.parse(endpoint);
 
 // create an instance of the `SocksProxyAgent` class with the proxy server information
-// NOTE: the `true` second argument! Means to use TLS encryption on the socket
-var agent = new SocksProxyAgent(proxy, true);
+var agent = new SocksProxyAgent(proxy);
 opts.agent = agent;
 
 https.get(opts, function (res) {


### PR DESCRIPTION
It was removed at https://github.com/TooTallNate/node-socks-proxy-agent/commit/74e3b6f2255d274015efef59a281bb9d1c514c16.