### PR TITLE
Add typescript definition file

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,21 @@
+declare module "socks-proxy-agent" {
+  import * as https from "https";
+  namespace SocksProxyAgent {
+    interface SocksProxyAgentOptions {
+      host: string;
+      port: number | string;
+      protocol: string;
+      auth?: string;
+      [key: string]: any;
+    }
+  }
+
+  // SocksProxyAgent doesnt *actually* extend https.Agent.
+  // This code is copied from https-proxy-agent.
+  // Please refer: https://github.com/TooTallNate/node-https-proxy-agent/blob/200cc9f18ff25e6cb8e5f1d61db5fea159a103dd/index.d.ts#L16-L19
+  class SocksProxyAgent extends https.Agent {
+    constructor(opts: SocksProxyAgent.SocksProxyAgentOptions | string);
+  }
+
+  export = SocksProxyAgent;
+}

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "4.0.2",
   "description": "A SOCKS proxy `http.Agent` implementation for HTTP and HTTPS",
   "main": "./index.js",
+  "types": "./index.d.ts",
   "scripts": {
     "test": "mocha --reporter spec"
   },


### PR DESCRIPTION
refs: #43 

I added typescript definition file. I referred `https-proxy-agent` typescript definition: https://github.com/TooTallNate/node-https-proxy-agent/blob/master/index.d.ts