### PR TITLE
Support tls wrapper around socks server

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ namespace createSocksProxyAgent {
 		host?: string | null;
 		port?: string | number | null;
 		username?: string | null;
+		tls?: boolean | null;
 	}
 
 	export interface SocksProxyAgentOptions


### PR DESCRIPTION
SOCKS5 simple authentication is made in clear.

Adding TLS tunnel with https://www.stunnel.org/ around https://www.inet.no/dante/ allow protecting SOCKS5 simple authentication with TLS tunnel.

stunnel4 config file :

```text
[certificate-based server]
accept = 1080
connect = 127.0.0.1:1081
cert = /etc/letsencrypt/live/proxy.agix.dev/fullchain.pem
key = /etc/letsencrypt/live/proxy.agix.dev/privkey.pem
``` 

dante conf:

```text
logoutput: syslog stdout
internal: lo port = 1081
external: ens4 # replace with your external interface
clientmethod: none
socksmethod: username
user.privileged: root
user.unprivileged: nobody
user.libwrap: nobody
client pass {
       from: 0.0.0.0/0 to: 0.0.0.0/0
       log: error connect disconnect
}
socks pass {
        from: 0.0.0.0/0 to: 0.0.0.0/0
        log: error connect disconnect
}
```

`dante` username method use linux account so just add a service account

`useradd -r test-tls-socks` then `passwd test-tls-socks` to set a password.


Code to test:
```
const got = require('got')
const { SocksProxyAgent } = require('socks-proxy-agent');
const URL_TO_PING = 'https://nodejs.org/api/';

(async () => {
  const info = {
    host: 'proxy.agix.dev', // set hostname of your socks proxy
    userId: 'test-tls-socks',
    password: 'password_you_choose',
    tls: true,
  }
  const res = await got(
    URL_TO_PING,
    {
      agent: {
        http: new SocksProxyAgent(info),
        https: new SocksProxyAgent(info),
      },
    }
  )
  console.log(res.body);
})()
```