### PR TITLE
fix: remove : from the cases

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -49,18 +49,18 @@ function parseSocksProxy(
 	// figure out if we want socks v4 or v5, based on the "protocol" used.
 	// Defaults to 5.
 	if (opts.protocol) {
-		switch (opts.protocol) {
-			case 'socks4:':
+		switch (opts.protocol.replace(':', '')) {
+			case 'socks4':
 				lookup = true;
 			// pass through
-			case 'socks4a:':
+			case 'socks4a':
 				type = 4;
 				break;
-			case 'socks5:':
+			case 'socks5':
 				lookup = true;
 			// pass through
-			case 'socks:': // no version specified, default to 5h
-			case 'socks5h:':
+			case 'socks': // no version specified, default to 5h
+			case 'socks5h':
 				type = 5;
 				break;
 			default:


### PR DESCRIPTION
This change makes the library a bit reliable for those libraries that remove `:` from the protocol field.