### PR TITLE
error TS1192: Module '"net"' has no default export.

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "url": "https://github.com/TooTallNate/node-socks-proxy-agent/issues"
   },
   "dependencies": {
-    "agent-base": "6.0.2",
+    "agent-base": "^6.0.2",
     "debug": "4",
     "socks": "^2.3.3"
   },

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "url": "https://github.com/TooTallNate/node-socks-proxy-agent/issues"
   },
   "dependencies": {
-    "agent-base": "6",
+    "agent-base": "6.0.2",
     "debug": "4",
     "socks": "^2.3.3"
   },


### PR DESCRIPTION
agent-base improve  statements in this pull request 

https://github.com/TooTallNate/node-agent-base/pull/57

node_modules/agent-base/dist/src/index.d.ts:2:8 - error TS1192: Module '"net"' has no default export.

2 import net from 'net';
 
in Type-Script Version 4.2.3