### PR TITLE
feat: allow passing tls connection options

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -134,7 +134,7 @@ export default class SocksProxyAgent extends Agent {
 		const parsedProxy = parseSocksProxy(opts);
 		this.lookup = parsedProxy.lookup;
 		this.proxy = parsedProxy.proxy;
-		this.tlsConnectionOptions = opts.tls;
+		this.tlsConnectionOptions = opts.tls || {};
 	}
 
 	/**

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -134,8 +134,7 @@ export default class SocksProxyAgent extends Agent {
 		const parsedProxy = parseSocksProxy(opts);
 		this.lookup = parsedProxy.lookup;
 		this.proxy = parsedProxy.proxy;
-
-		this.tlsConnectionOptions = opts.tls ?? {};
+		this.tlsConnectionOptions = opts.tls;
 	}
 
 	/**

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -115,7 +115,7 @@ function parseSocksProxy(
 export default class SocksProxyAgent extends Agent {
 	private lookup: boolean;
 	private proxy: SocksProxy;
-	private tlsRejectUnauthorized: boolean;
+	private tlsConnectionOptions: tls.ConnectionOptions;
 
 	constructor(_opts: string | SocksProxyAgentOptions) {
 		let opts: SocksProxyAgentOptions;
@@ -135,7 +135,7 @@ export default class SocksProxyAgent extends Agent {
 		this.lookup = parsedProxy.lookup;
 		this.proxy = parsedProxy.proxy;
 
-		this.tlsRejectUnauthorized = opts.tls?.rejectUnauthorized ?? false;
+		this.tlsConnectionOptions = opts.tls ?? {};
 	}
 
 	/**
@@ -179,7 +179,7 @@ export default class SocksProxyAgent extends Agent {
 				...omit(opts, 'host', 'hostname', 'path', 'port'),
 				socket,
 				servername,
-				rejectUnauthorized: this.tlsRejectUnauthorized
+				...this.tlsConnectionOptions,
 			});
 		}
 

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -115,6 +115,7 @@ function parseSocksProxy(
 export default class SocksProxyAgent extends Agent {
 	private lookup: boolean;
 	private proxy: SocksProxy;
+	private tlsRejectUnauthorized: boolean;
 
 	constructor(_opts: string | SocksProxyAgentOptions) {
 		let opts: SocksProxyAgentOptions;
@@ -133,6 +134,8 @@ export default class SocksProxyAgent extends Agent {
 		const parsedProxy = parseSocksProxy(opts);
 		this.lookup = parsedProxy.lookup;
 		this.proxy = parsedProxy.proxy;
+
+		this.tlsRejectUnauthorized = opts.tls?.rejectUnauthorized ?? false;
 	}
 
 	/**
@@ -175,7 +178,8 @@ export default class SocksProxyAgent extends Agent {
 			return tls.connect({
 				...omit(opts, 'host', 'hostname', 'path', 'port'),
 				socket,
-				servername
+				servername,
+				rejectUnauthorized: this.tlsRejectUnauthorized
 			});
 		}
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import { Url } from 'url';
 import { SocksProxy } from 'socks';
+import { ConnectionOptions } from 'tls';
 import { AgentOptions } from 'agent-base';
 import _SocksProxyAgent from './agent';
 
@@ -10,10 +11,13 @@ function createSocksProxyAgent(
 }
 
 namespace createSocksProxyAgent {
+	type TlsOptions = Pick<ConnectionOptions, "rejectUnauthorized">;
+
 	interface BaseSocksProxyAgentOptions {
 		host?: string | null;
 		port?: string | number | null;
 		username?: string | null;
+		tls?: TlsOptions | null;
 	}
 
 	export interface SocksProxyAgentOptions

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { Url } from 'url';
 import { SocksProxy } from 'socks';
-import { ConnectionOptions } from 'tls';
+import tls from 'tls';
 import { AgentOptions } from 'agent-base';
 import _SocksProxyAgent from './agent';
 
@@ -11,13 +11,11 @@ function createSocksProxyAgent(
 }
 
 namespace createSocksProxyAgent {
-	type TlsOptions = Pick<ConnectionOptions, "rejectUnauthorized">;
-
 	interface BaseSocksProxyAgentOptions {
 		host?: string | null;
 		port?: string | number | null;
 		username?: string | null;
-		tls?: TlsOptions | null;
+		tls?: tls.ConnectionOptions | null;
 	}
 
 	export interface SocksProxyAgentOptions


### PR DESCRIPTION
Adds support for `rejectUnauthorized`.

closes https://github.com/TooTallNate/node-socks-proxy-agent/issues/57