### PR TITLE
Use the request's configured lookup if client-side lookup is enabled

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,6 @@
   ],
   "dependencies": {
     "agent-base": "^6.0.2",
-    "cacheable-lookup": "~6.0.4",
     "debug": "^4.3.3",
     "socks": "^2.6.2"
   },
@@ -92,7 +91,9 @@
     "@commitlint/config-conventional": "latest",
     "@types/debug": "latest",
     "@types/node": "latest",
+    "cacheable-lookup": "^6.0.4",
     "conventional-github-releaser": "latest",
+    "dns2": "^2.0.1",
     "finepack": "latest",
     "git-authors-cli": "latest",
     "mocha": "latest",


### PR DESCRIPTION
HTTP requests can be [configured](https://nodejs.org/api/http.html#httprequesturl-options-callback) with a `lookup` option, which provides a method that should be used instead of `dns.lookup` to resolve names. This is useful for lots of cases including DNS caching and custom resolution.

When using the Socks proxy agent with client-side DNS lookups, this was ignored, and `dns.lookup` was always called instead. In some environments (e.g. my use case, where I use custom resolution to resolve certain otherwise-unresolvable hostnames) this means that requests will fail to resolve only when using a socks proxy, but work fine the rest of the time.

This PR is a small change to fix that, by using the lookup param in preference to the default lookup method if it's set.