### PR TITLE
Include types file extension in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "6.1.0",
   "description": "A SOCKS proxy `http.Agent` implementation for HTTP and HTTPS",
   "main": "dist/index",
-  "typings": "dist/index",
+  "typings": "dist/index.d.ts",
   "files": [
     "dist"
   ],


### PR DESCRIPTION
Otherwise, the TypeScript language service used in VS Code (and other editors) won't pick up the types.