### PR TITLE
jsonip.org -> ipinfo.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ const info = {
 };
 const agent = new SocksProxyAgent(info);
 
-https.get('https://jsonip.org', { agent }, (res) => {
+https.get('https://ipinfo.io', { agent }, (res) => {
 	console.log(res.headers);
 	res.pipe(process.stdout);
 });


### PR DESCRIPTION
It seems like jsonip.org is no more:

```
▲ (pear-vm) ~ {gru1} dig +short jsonip.org
▲ (pear-vm) ~ {gru1} curl jsonip.org
curl: (6) Could not resolve host: jsonip.org
```