### PR TITLE
fix: make opts.host work again

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,11 @@ import net from 'net'
 import tls from 'tls'
 
 interface BaseSocksProxyAgentOptions {
+  /**
+   * hostname is preferred over host
+   * 
+   * @deprecated
+   */
   host?: string | null;
   port?: string | number | null;
   username?: string | null;
@@ -25,10 +30,10 @@ function parseSocksProxy (opts: SocksProxyAgentOptions): { lookup: boolean, prox
   let lookup = false
   let type: SocksProxy['type'] = 5
 
-  const host = opts.hostname
+  const host = opts.hostname || opts.host
 
   if (host == null) {
-    throw new TypeError('No "host"')
+    throw new TypeError('No "hostname"')
   }
 
   if (typeof opts.port === 'number') {
@@ -110,7 +115,7 @@ const normalizeProxyOptions = (input: string | SocksProxyAgentOptions): SocksPro
     proxyOptions = input
   }
   if (proxyOptions == null) {
-    throw new TypeError('a SOCKS proxy server `host` and `port` must be specified!')
+    throw new TypeError('a SOCKS proxy server `hostname` and `port` must be specified!')
   }
 
   return proxyOptions


### PR DESCRIPTION
Fixes #95 

I'm not sure if it was intentional to completely remove `host` support at some point or or not, but since this was a breaking change introduced in a minor release, I want to make it work again. I inferred that you hostname should be used instead of host so I marked `host` as deprecated; please correct me if I'm wrong. I'm not personally attached to `host` so I think it's fine to remove it in a major release 😄.